### PR TITLE
Auto boost patch.

### DIFF
--- a/HiOctane.cpp
+++ b/HiOctane.cpp
@@ -62,6 +62,8 @@ void HiOctaneEntry()
     LargeVehiclePatch::Install();
 
     LoadingScreenPatch::Install();
+	
+	AutomaticBoostPatch::Install();
 
     // CarsDialoguePatches::install();
 

--- a/HiOctane.cpp
+++ b/HiOctane.cpp
@@ -63,7 +63,7 @@ void HiOctaneEntry()
 
     LoadingScreenPatch::Install();
 	
-	AutomaticBoostPatch::Install();
+    AutomaticBoostPatch::Install();
 
     // CarsDialoguePatches::install();
 

--- a/Hooks.h
+++ b/Hooks.h
@@ -504,3 +504,13 @@ namespace LoadingScreenPatch {
     }
 
 };
+
+namespace AutomaticBoostPatch {
+
+    DWORD* boostthing = (DWORD*)0x006ED818;
+
+    void Install() {
+        SetReadWritePermission((DWORD*)(0x006ED818), 1); *(DWORD*)(0x006ED818) = 3;
+        Logging::Log("[AutomaticBoostPatch::Install] Successfully installed patch!\n");
+    }
+};


### PR DESCRIPTION
Allows the game to have Level 3 boost right away without having the need to go to Story Mode to enable it.